### PR TITLE
(으)로 이외의 조사가 -ㄹ 받침 뒤에 올 때 오작동하던 문제 수정 외

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 csjosa
 ======
 
-c# 한글 조사 처리입니다. 현재는 **모노**에서만 빌드 및 실행 테스트되었습니다. 
+c# 한글 조사 처리입니다. 모노와 VS2013에서 빌드 및 실행 테스트되었습니다. 
 
 ## 예제
 
@@ -15,8 +15,15 @@ c# 한글 조사 처리입니다. 현재는 **모노**에서만 빌드 및 실�
         {
             public static void Main()
             {
-                string src = "아노아(은)는 자루(와)과 오리(을)를 칭송하고 절(으)로 들어갔습니다.";
-                Console.WriteLine(Korean.ReplaceJosa(src));
+                Console.WriteLine(Korean.ReplaceJosa("네(이)가 잘못했어. 확률(이)가 이상해. 덫(이)가 깔렸어."));
+                Console.WriteLine(Korean.ReplaceJosa("너(와)과 함께 할게. 글(와)과 그림. 빛(와)과 어둠."));
+                Console.WriteLine(Korean.ReplaceJosa("수녀(을)를 존경했어. 남자들(을)를 입히다. 버튼(을)를 만지지 마."));
+                Console.WriteLine(Korean.ReplaceJosa("우리(은)는 끝이야. 쌀(은)는 필요없어. 갑옷(은)는 찢었다."));
+                Console.WriteLine(Korean.ReplaceJosa("진우(아)야, 그것도 몰라? 경렬(아)야, 진정해. 상현(아)야, 뭐해?"));
+                Console.WriteLine(Korean.ReplaceJosa("진우(이)여. 닥쳐라. 경렬(이)여. 이리 오라. 상현(이)여. 아무 일도 아니다."));
+                Console.WriteLine(Korean.ReplaceJosa("부두(으)로 가야 해. 대궐(으)로 가거나. 집(으)로 갈래?"));
+                Console.WriteLine(Korean.ReplaceJosa("나(이)라고 어쩔 수 있겠니? 별(이)라고 불러줘. 라면(이)라고 했잖아."));
+                Console.ReadKey();
             }
         }
     }
@@ -28,4 +35,11 @@ c# 한글 조사 처리입니다. 현재는 **모노**에서만 빌드 및 실�
 #### 실행
 
     $ mono csjosa.exe 
-    아노아는 자루와 오리를 칭송하고 절로 들어갔습니다.
+    네가 잘못했어. 확률이 이상해. 덫이 깔렸어.
+    너와 함께 할게. 글과 그림. 빛과 어둠.
+    수녀를 존경했어. 남자들을 입히다. 버튼을 만지지 마.
+    우리는 끝이야. 쌀은 필요없어. 갑옷은 찢었다.
+    진우야, 그것도 몰라? 경렬아, 진정해. 상현아, 뭐해?
+    진우여, 닥쳐라. 경렬이여, 이리 오라. 상현이여, 아무 일도 아니다.
+    부두로 가야 해. 대궐로 가거나. 집으로 갈래?
+    나라고 어쩔 수 있겠니? 별이라고 불러줘. 라면이라고 했잖아.

--- a/csjosa.cs
+++ b/csjosa.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
@@ -37,7 +37,8 @@ namespace Myevan
                     if (josaMatch.Index > 0)
                     {
                         var prevChar = src[josaMatch.Index - 1];
-                        if (HasJong(prevChar))
+                        if ((HasJong(prevChar) && josaMatch.Value != "(으)로") || 
+                            (HasJongExceptRieul(prevChar) && josaMatch.Value == "(으)로"))
                         {
                             strBuilder.Append(josaPair.josa1);
                         }
@@ -65,10 +66,7 @@ namespace Myevan
                     int jongCode = localCode % 28;
                     if (jongCode > 0)
                     {
-                        if (jongCode == 8) // ㄹ 종성 예외 처리
-                            return false;
-                        else
-                            return true;
+                        return true;
                     }
                     else
                     {
@@ -81,7 +79,28 @@ namespace Myevan
                 }
             }
 
-            Regex _josaRegex = new Regex(@"\(이\)가|\(와\)과|\(을\)를|\(은\)는|\(으\)로");
+            static bool HasJongExceptRieul(char inChar)
+            {
+                if (inChar >= 0xAC00 && inChar <= 0xD7A3)
+                {
+                    int localCode = inChar - 0xAC00;
+                    int jongCode = localCode % 28;
+                    if (jongCode == 8 || jongCode == 0)
+                    {
+                        return false;
+                    }
+                    else
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            Regex _josaRegex = new Regex(@"\(이\)가|\(와\)과|\(을\)를|\(은\)는|\(아\)야|\(이\)여|\(으\)로|\(이\)라고");
 
             Dictionary<string, JosaPair> _josaPatternPaird = new Dictionary<string, JosaPair>
             {
@@ -89,7 +108,10 @@ namespace Myevan
                 { "(와)과", new JosaPair("과", "와") },
                 { "(을)를", new JosaPair("을", "를") },
                 { "(은)는", new JosaPair("은", "는") },
+                { "(아)야", new JosaPair("아", "야") },
+                { "(이)여", new JosaPair("이여", "여") },
                 { "(으)로", new JosaPair("으로", "로") },
+                { "(이)라고", new JosaPair("이라고", "라고") },
             };
 
         }

--- a/main.cs
+++ b/main.cs
@@ -6,8 +6,15 @@ namespace Myevan
     {
         public static void Main()
         {
-            string src = "아노아(은)는 자루(와)과 오리(을)를 칭송하고 절(으)로 들어갔습니다.";
-            Console.WriteLine(Korean.ReplaceJosa(src));
+            Console.WriteLine(Korean.ReplaceJosa("네(이)가 잘못했어. 확률(이)가 이상해. 덫(이)가 깔렸어."));
+			Console.WriteLine(Korean.ReplaceJosa("너(와)과 함께 할게. 글(와)과 그림. 빛(와)과 어둠."));
+			Console.WriteLine(Korean.ReplaceJosa("수녀(을)를 존경했어. 남자들(을)를 입히다. 버튼(을)를 만지지 마."));
+			Console.WriteLine(Korean.ReplaceJosa("우리(은)는 끝이야. 쌀(은)는 필요없어. 갑옷(은)는 찢었다."));
+			Console.WriteLine(Korean.ReplaceJosa("진우(아)야, 그것도 몰라? 경렬(아)야, 진정해. 상현(아)야, 뭐해?"));
+  			Console.WriteLine(Korean.ReplaceJosa("진우(이)여, 닥쳐라. 경렬(이)여, 이리 오라. 상현(이)여, 아무 일도 아니다."));
+  			Console.WriteLine(Korean.ReplaceJosa("부두(으)로 가야 해. 대궐(으)로 가거나. 집(으)로 갈래?"));
+            Console.WriteLine(Korean.ReplaceJosa("나(이)라고 어쩔 수 있겠니? 별(이)라고 불러줘. 라면(이)라고 했잖아."));
+            Console.ReadKey();
         }
     }
 }


### PR DESCRIPTION
1) 기존 처리에서 "(이)가"나 "(은)는" 등의 조사 쌍에서, "(으)로"를 처리하기 위해 삽입했던 ㄹ 종성 예외처리 루틴이 동일하게 적용되어 잘못된 결과를 내고 있었습니다. (ex: 확률가 낮다, 법률는 지켜야 한다)
기존 소스코드의 HasJong 메소드에서 ㄹ 종성 예외처리를 제거하고, HasJongExceptRieul 메소드를 추가하여 (으)로를 처리할 때는 HasJong 메소드 대신 HasJongExceptRieul 메소드를 이용하게 하였습니다.

2) 다음 세 조사의 처리를 추가하였습니다: (아)야, (이)여, (이)라고.

3) main.cs에 포함되어 있던 테스트를 현재까지 추가한 케이스 모두에 대해 정상적인 출력이 되는지를 체크하는 테스트로 세분화하였습니다.

4) 위 테스트는 VS2013에서 진행되었고, 이와 같은 변경에 따라 README.md를 변경하였습니다.
