### PR TITLE
(이)라고에 한정되었던 처리를 (이)라면, (이)라는 등에 적용할 수 있도록 개선

### DIFF
--- a/csjosa.cs
+++ b/csjosa.cs
@@ -100,7 +100,7 @@ namespace Myevan
                 }
             }
 
-            Regex _josaRegex = new Regex(@"\(이\)가|\(와\)과|\(을\)를|\(은\)는|\(아\)야|\(이\)여|\(으\)로|\(이\)라고");
+            Regex _josaRegex = new Regex(@"\(이\)가|\(와\)과|\(을\)를|\(은\)는|\(아\)야|\(이\)여|\(으\)로|\(이\)라");
 
             Dictionary<string, JosaPair> _josaPatternPaird = new Dictionary<string, JosaPair>
             {
@@ -111,7 +111,7 @@ namespace Myevan
                 { "(아)야", new JosaPair("아", "야") },
                 { "(이)여", new JosaPair("이여", "여") },
                 { "(으)로", new JosaPair("으로", "로") },
-                { "(이)라고", new JosaPair("이라고", "라고") },
+                { "(이)라", new JosaPair("이라", "라") },
             };
 
         }


### PR DESCRIPTION
이전에 추가한 (이)라고를 사용해본 결과, 같은 형식이 (이)라면, (이)라는 등 다른 조사에도 적용될 수 있는 걸 발견하여 그 부분을 좀 더 폭넓게 쓸 수 있도록 수정하였습니다.
